### PR TITLE
auth to auto typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
             <p>BrisJS is dedicated to a harassment-free experience for everyone. Please make sure to familiareze yourself with our <a href="#conduct">Code of Conduct</a></p>
 
           <h3>The tech</h3>
-          <p>The Auth &amp; General venue is fitted out with 1080p displays
+          <p>The Auto &amp; General venue is fitted out with 1080p displays
             mirrored throughout the venue. These support HDMI &amp; mini DP
             output, however audio is not yet supported via this output.</p>
           <p>There is room wide amplification for your presentation, with a lapel &amp; hand-held mic.</p>
@@ -157,7 +157,7 @@
           <p>If you have special requirements on the night (either technical or personal), please let us know.</p>
           <h3>Presentation tips</h3>
           <p>Follow these tips to help the audience get the most from your talk:</p>
-          <ul>  
+          <ul>
             <li>Use text that is large enough to read from the back of the room. This applies not only to slides but also your code editor, command line and browser if you are doing a demo - bump up the font size or use the accessibility features of your O.S. to zoom in on part of the screen.</li>
             <li>Some colors are harder to read than others on the displays. Adopt a high-contrast color scheme for text to make it easier to read, and consider people who are colorblind when selecting colors.</li>
             <li>To get the best result for the recording of your talk, remember to speak clearly using the microphone, and if someone asks a question, try to repeat or rephrase the question as part of your answer so that it also gets recorded.</li>


### PR DESCRIPTION
A quick typo fix of `Auth & General venue` to `Auto & General venue`